### PR TITLE
Openllm fix

### DIFF
--- a/llm_autoeval/table.py
+++ b/llm_autoeval/table.py
@@ -67,7 +67,9 @@ def make_table(result_dict, task):
     values = []
 
     for k, dic in sorted(result_dict["results"].items()):
-        version = result_dict["versions"][k]
+        # Correctly use get() to safely access the dictionary
+        version = result_dict["versions"].get(k, "N/A")  # Use get() on the versions dictionary
+        
         percent = k == "squad2"
         for m, v in dic.items():
             if m.endswith("_stderr"):
@@ -93,10 +95,7 @@ def make_table(result_dict, task):
                         # If conversion fails, use the original string value
                         v_formatted = v
 
-                    if isinstance(version, str):
-                        values.append([k, version, m, v_formatted, "", ""])
-                    else:
-                        values.append([k, version, m, v_formatted, "", ""])
+                    values.append([k, version, m, v_formatted, "", ""])
 
             k = ""
             version = ""

--- a/llm_autoeval/table.py
+++ b/llm_autoeval/table.py
@@ -33,6 +33,8 @@ def calculate_average(data, task):
             return data["results"]["arc_challenge"]["acc_norm,none"] * 100
         elif task == "hellaswag":
             return data["results"]["hellaswag"]["acc_norm,none"] * 100
+        elif task == "mmlu":
+            return data["results"]["mmlu"]["acc,none"] * 100
         elif task == "truthfulqa":
             value = data["results"]["truthfulqa_mc2"]["acc,none"]
             return 0.0 if math.isnan(value) else value * 100
@@ -41,7 +43,7 @@ def calculate_average(data, task):
         elif task == "gsm8k":
             return (
                 data["results"]["gsm8k"]["exact_match,get-answer"] * 100
-            )  # should be "acc" instead
+            )
 
     elif BENCHMARK == "nous":
         if task == "agieval":

--- a/llm_autoeval/upload.py
+++ b/llm_autoeval/upload.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 
 

--- a/main.py
+++ b/main.py
@@ -83,6 +83,10 @@ def _make_lighteval_summary(directory: str, elapsed_time: float) -> str:
     summary += final_table
     return summary
 
+def _make_eqbench_summary(directory: str, elapsed_time: float) -> str:
+    result_dict = _get_result_dict(directory)
+    summary = f"## {MODEL_ID.split('/')[-1]} - {BENCHMARK.capitalize()}\n\n"
+    return summary
 
 def main(directory: str, elapsed_time: float) -> None:
     # Tasks
@@ -90,6 +94,8 @@ def main(directory: str, elapsed_time: float) -> None:
         summary = _make_autoeval_summary(directory, elapsed_time)
     elif BENCHMARK == "lighteval":
         summary = _make_lighteval_summary(directory, elapsed_time)
+    elif BENCHMARK == "eq-bench":
+        summary = _make_eqbench_summary(directory, elapsed_time)
     else:
         raise NotImplementedError(
             f"BENCHMARK should be 'openllm' or 'nous' (current value = {BENCHMARK})"

--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
+import argparse
 import json
 import logging
 import os
-import argparse
 import time
 
-from llm_autoeval.table import make_table, make_final_table
+from llm_autoeval.table import make_final_table, make_table
 from llm_autoeval.upload import upload_to_github_gist
 
 logging.basicConfig(level=logging.INFO)
@@ -76,17 +76,19 @@ def _get_result_dict(directory: str) -> dict:
 
 def _make_lighteval_summary(directory: str, elapsed_time: float) -> str:
     from lighteval.evaluator import make_results_table
-    
+
     result_dict = _get_result_dict(directory)
     final_table = make_results_table(result_dict)
     summary = f"## {MODEL_ID.split('/')[-1]} - {BENCHMARK.capitalize()}\n\n"
     summary += final_table
     return summary
 
+
 def _make_eqbench_summary(directory: str, elapsed_time: float) -> str:
     result_dict = _get_result_dict(directory)
     summary = f"## {MODEL_ID.split('/')[-1]} - {BENCHMARK.capitalize()}\n\n"
     return summary
+
 
 def main(directory: str, elapsed_time: float) -> None:
     # Tasks

--- a/runpod.sh
+++ b/runpod.sh
@@ -86,7 +86,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     benchmark="arc"
     accelerate launch -m lm_eval \
         --model hf \
-        --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
+        --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks arc_challenge \
         --num_fewshot 25 \
         --batch_size auto \
@@ -95,7 +95,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     benchmark="hellaswag"
     accelerate launch -m lm_eval \
         --model hf \
-        --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
+        --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks hellaswag \
         --num_fewshot 10 \
         --batch_size auto \
@@ -104,7 +104,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     benchmark="mmlu"
     accelerate launch -m lm_eval \
         --model hf \
-        --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
+        --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks mmlu \
         --num_fewshot 5 \
         --batch_size auto \
@@ -114,7 +114,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     benchmark="truthfulqa"
     accelerate launch -m lm_eval \
         --model hf \
-        --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
+        --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks truthfulqa \
         --num_fewshot 0 \
         --batch_size auto \
@@ -123,7 +123,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     benchmark="winogrande"
     accelerate launch -m lm_eval \
         --model hf \
-        --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
+        --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks winogrande \
         --num_fewshot 5 \
         --batch_size auto \
@@ -132,7 +132,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     benchmark="gsm8k"
     accelerate launch -m lm_eval \
         --model hf \
-        --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
+        --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks gsm8k \
         --num_fewshot 5 \
         --batch_size auto \

--- a/runpod.sh
+++ b/runpod.sh
@@ -80,7 +80,7 @@ if [ "$BENCHMARK" == "nous" ]; then
 elif [ "$BENCHMARK" == "openllm" ]; then
     git clone https://github.com/EleutherAI/lm-evaluation-harness
     cd lm-evaluation-harness
-    pip install -e
+    pip install -e .
     pip install accelerate
 
     benchmark="arc"

--- a/runpod.sh
+++ b/runpod.sh
@@ -80,11 +80,11 @@ if [ "$BENCHMARK" == "nous" ]; then
 elif [ "$BENCHMARK" == "openllm" ]; then
     git clone https://github.com/EleutherAI/lm-evaluation-harness
     cd lm-evaluation-harness
-    pip install -e ".[vllm,promptsource]"
-    pip install langdetect immutabledict
+    pip install -e
+    pip install accelerate
 
     benchmark="arc"
-    lm_eval --model vllm \
+    accelerate launch --model lm_eval \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks arc_challenge \
         --num_fewshot 25 \
@@ -92,24 +92,24 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="hellaswag"
-    lm_eval --model vllm \
+    accelerate launch --model lm_eval \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks hellaswag \
         --num_fewshot 10 \
         --batch_size auto \
         --output_path ./${benchmark}.json
 
-    # benchmark="mmlu"
-    # lm_eval --model vllm \
-    #     --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
-    #     --tasks mmlu \
-    #     --num_fewshot 5 \
-    #     --batch_size auto \
-    #     --verbosity DEBUG \
-    #     --output_path ./${benchmark}.json
+    benchmark="mmlu"
+    accelerate launch --model lm_eval \
+        --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
+        --tasks mmlu \
+        --num_fewshot 5 \
+        --batch_size auto \
+        --verbosity DEBUG \
+        --output_path ./${benchmark}.json
     
     benchmark="truthfulqa"
-    lm_eval --model vllm \
+    accelerate launch --model lm_eval \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks truthfulqa \
         --num_fewshot 0 \
@@ -117,7 +117,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="winogrande"
-    lm_eval --model vllm \
+    accelerate launch --model lm_eval \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks winogrande \
         --num_fewshot 5 \
@@ -125,7 +125,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="gsm8k"
-    lm_eval --model vllm \
+    accelerate launch --model lm_eval \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks gsm8k \
         --num_fewshot 5 \

--- a/runpod.sh
+++ b/runpod.sh
@@ -37,7 +37,7 @@ if [ "$BENCHMARK" == "nous" ]; then
     pip install -e .
 
     benchmark="agieval"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [1/4] =================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -47,7 +47,7 @@ if [ "$BENCHMARK" == "nous" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="gpt4all"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [2/4] =================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -57,7 +57,7 @@ if [ "$BENCHMARK" == "nous" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="truthfulqa"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [3/4] =================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -67,7 +67,7 @@ if [ "$BENCHMARK" == "nous" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="bigbench"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [4/4] =================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -88,7 +88,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     pip install accelerate
 
     benchmark="arc"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [1/6] =================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -98,7 +98,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="hellaswag"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [2/6] =================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -108,7 +108,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="mmlu"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [3/6] =================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -119,7 +119,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="truthfulqa"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [4/6] =================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -129,7 +129,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="winogrande"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [5/6] =================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -139,7 +139,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="gsm8k"
-    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [6/6] =================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -186,6 +186,27 @@ elif [ "$BENCHMARK" == "lighteval" ]; then
     end=$(date +%s)
 
     python ../llm-autoeval/main.py ./evals/results $(($end-$start))
+
+elif [ "$BENCHMARK" == "eq-bench" ]; then
+    git clone https://github.com/EleutherAI/lm-evaluation-harness
+    cd lm-evaluation-harness
+    pip install -e .
+    pip install accelerate
+
+    benchmark="eq-bench"
+    echo "================== $(echo $benchmark | tr '[:lower:]' '[:upper:]') [1/6] =================="
+    accelerate launch -m lm_eval \
+        --model hf \
+        --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
+        --tasks eq_bench \
+        --num_fewshot 0 \
+        --batch_size auto \
+        --output_path ./${benchmark}.json
+
+    end=$(date +%s)
+
+    python ../llm-autoeval/main.py ./evals/results $(($end-$start))
+
 else
     echo "Error: Invalid BENCHMARK value. Please set BENCHMARK to 'nous', 'openllm', or 'lighteval'."
 fi

--- a/runpod.sh
+++ b/runpod.sh
@@ -84,7 +84,8 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     pip install accelerate
 
     benchmark="arc"
-    accelerate launch --model lm_eval \
+    accelerate launch -m lm_eval \
+        --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks arc_challenge \
         --num_fewshot 25 \
@@ -92,7 +93,8 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="hellaswag"
-    accelerate launch --model lm_eval \
+    accelerate launch -m lm_eval \
+        --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks hellaswag \
         --num_fewshot 10 \
@@ -100,7 +102,8 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="mmlu"
-    accelerate launch --model lm_eval \
+    accelerate launch -m lm_eval \
+        --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks mmlu \
         --num_fewshot 5 \
@@ -109,7 +112,8 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="truthfulqa"
-    accelerate launch --model lm_eval \
+    accelerate launch -m lm_eval \
+        --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks truthfulqa \
         --num_fewshot 0 \
@@ -117,7 +121,8 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="winogrande"
-    accelerate launch --model lm_eval \
+    accelerate launch -m lm_eval \
+        --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks winogrande \
         --num_fewshot 5 \
@@ -125,7 +130,8 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="gsm8k"
-    accelerate launch --model lm_eval \
+    accelerate launch -m lm_eval \
+        --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,gpu_memory_utilization=0.8,trust_remote_code=$TRUST_REMOTE_CODE \
         --tasks gsm8k \
         --num_fewshot 5 \

--- a/runpod.sh
+++ b/runpod.sh
@@ -37,6 +37,7 @@ if [ "$BENCHMARK" == "nous" ]; then
     pip install -e .
 
     benchmark="agieval"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -46,6 +47,7 @@ if [ "$BENCHMARK" == "nous" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="gpt4all"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -55,6 +57,7 @@ if [ "$BENCHMARK" == "nous" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="truthfulqa"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -64,6 +67,7 @@ if [ "$BENCHMARK" == "nous" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="bigbench"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     python main.py \
         --model hf-causal \
         --model_args pretrained=$MODEL_ID,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -84,6 +88,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
     pip install accelerate
 
     benchmark="arc"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -93,6 +98,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="hellaswag"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -102,6 +108,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
 
     benchmark="mmlu"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -112,6 +119,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="truthfulqa"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -121,6 +129,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="winogrande"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -130,6 +139,7 @@ elif [ "$BENCHMARK" == "openllm" ]; then
         --output_path ./${benchmark}.json
     
     benchmark="gsm8k"
+    echo "==================$(echo $benchmark | tr '[:lower:]' '[:upper:]')=================="
     accelerate launch -m lm_eval \
         --model hf \
         --model_args pretrained=${MODEL_ID},dtype=auto,trust_remote_code=$TRUST_REMOTE_CODE \
@@ -177,7 +187,7 @@ elif [ "$BENCHMARK" == "lighteval" ]; then
 
     python ../llm-autoeval/main.py ./evals/results $(($end-$start))
 else
-    echo "Error: Invalid BENCHMARK value. Please set BENCHMARK to 'nous' or 'openllm'."
+    echo "Error: Invalid BENCHMARK value. Please set BENCHMARK to 'nous', 'openllm', or 'lighteval'."
 fi
 
 if [ "$DEBUG" == "False" ]; then


### PR DESCRIPTION
It took me a while but it fixes an old issue with the MMLU dataset. It also replaces vllm with accelerate to be more consistent with the Open LLM Leaderboard's results. It doesn't use the same version of lm-evaluation-harness for convenience, but results look very close. For instance:

|                          Model                           | ARC |HellaSwag|MMLU |TruthfulQA|Winogrande|GSM8K|Average|
|----------------------------------------------------------|----:|--------:|----:|---------:|---------:|----:|------:|
|[pythia-70m](https://huggingface.co/EleutherAI/pythia-70m)|22.18|    27.39|25.29|     46.84|     51.07| 0.23|  28.83|

Compared with https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard

Know issue: the tables summarizing the results are poorly formatted. I don't think it's too important so I'll hopefully fix it later, I made several inconclusive attempts.